### PR TITLE
Adding in Adobe Target as a provider

### DIFF
--- a/common/providers.js
+++ b/common/providers.js
@@ -891,6 +891,55 @@ var OmnibugProvider = {
             }
             return false;
         }
+    },
+
+    ADOBETARGET : {
+        key: "ADOBETARGET"
+        , name: "Adobe Target"
+        , pattern: /\.tt\.omtrdc\.net\//
+        , keys: {
+            mbox:              "Mbox Name"
+            , mboxType:          "Mbox Type"
+            , mboxCount:         "Mbox Count"
+            , mboxId:            "Mbox ID"
+            , mboxSession:       "Mbox Session"
+            , mboxPC:            "Mbox PC ID"
+            , mboxPage:          "Mbox Page ID"
+            , clientCode:        "Client Code"
+            , mboxHost:          "Page Host"
+            , mboxURL:           "Page URL"
+            , mboxReferrer:      "Page Referrer"
+            , screenHeight:      "Screen Height"
+            , screenWidth:       "Screen Width"
+            , browserWidth:      "Browser Width"
+            , browserHeight:     "Browser Height"
+            , browserTimeOffset: "Browser Timezone Offset"
+            , colorDepth:        "Browser Color Depth"
+            , mboxXDomain:       "CrossDomain Enabled"
+            , mboxTime:          "Timestamp"
+            , mboxVersion:       "Library Version"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        },
+        handleCustom: function( url, rv, raw ) {
+            var matches =  url.match( /\/([^\/]+)\/mbox\/([^\/\?]+)/ );
+            if(matches !== null && matches.length == 3) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name]["clientCode"] = matches[1];
+                rv[this.key][this.name]["mboxType"] = matches[2];
+                raw["clientCode"] = matches[1];
+                raw["mboxType"] = matches[2];
+            }
+        }
     }
 
 };

--- a/firefox/chrome/content/omnibug/options.xul
+++ b/firefox/chrome/content/omnibug/options.xul
@@ -47,6 +47,7 @@
             <preference id="pref-prov-OPTIMIZELY" name="extensions.omnibug.provider.OPTIMIZELY" type="bool" />
             <preference id="pref-prov-SOPHUS3" name="extensions.omnibug.provider.SOPHUS3" type="bool" />
             <preference id="pref-prov-DOUBLECLICK" name="extensions.omnibug.provider.DOUBLECLICK" type="bool" />
+            <preference id="pref-prov-ADOBETARGET" name="extensions.omnibug.provider.ADOBETARGET" type="bool" />
         </preferences>
 
         <!-- file logging -->

--- a/firefox/defaults/preferences/omnibug.js
+++ b/firefox/defaults/preferences/omnibug.js
@@ -1,5 +1,5 @@
 // pattern to match in request url
-pref( "extensions.omnibug.defaultPattern", "/b/ss/|2o7|moniforce\.gif|dcs\.gif|__utm\.gif|\/collect\?" );
+pref( "extensions.omnibug.defaultPattern", "/b/ss/|2o7|moniforce\.gif|dcs\.gif|__utm\.gif|\/collect\?|\/tt\.omtrdc\.net\/" );
 pref( "extensions.omnibug.enableFileLogging", false );
 pref( "extensions.omnibug.highlightKeys", "events,products" );
 
@@ -39,4 +39,4 @@ pref( "extensions.omnibug.provider.KRUX", true );
 pref( "extensions.omnibug.provider.OPTIMIZELY", true );
 pref( "extensions.omnibug.provider.SOPHUS3", true );
 pref( "extensions.omnibug.provider.DOUBLECLICK", true );
-
+pref( "extensions.omnibug.provider.ADOBETARGET", true );

--- a/test/common/providerTest.js
+++ b/test/common/providerTest.js
@@ -327,4 +327,40 @@ describe( "Provider", function() {
         } );
     } );
 
+
+    describe( "Adobe Target", function() {
+        var url = "http://foobar.tt.omtrdc.net/m2/foobar/mbox/standard?mboxHost=foo.test.com&mboxSession=1234567890123-456789&mboxPC=1234567890123-456789.19_07&mboxPage=0987654321098-765432&screenHeight=1080&screenWidth=1920&browserWidth=1920&browserHeight=955&browserTimeOffset=-420&colorDepth=24&mboxXDomain=enabled&mboxCount=1&mbox=OmnibugTestMbox&mboxId=0&mboxTime=1425398080493&mboxURL=http%3A%2F%2Ffoo.test.com%2Fsample-mbox%2Fpage.html&mboxReferrer=http%3A%2F%2Ffoo.test.com%2Fsome-sample-referrer&mboxVersion=55",
+            provider = OmnibugProvider.getProviderForUrl( url );
+
+        it( "should return the Adobe Target provider", function() {
+            expect( provider.key ).toBe( "ADOBETARGET" );
+            expect( provider.name ).toBe( "Adobe Target" );
+        } );
+
+        it( "should allow a known key", function() {
+            var rv = {}, raw = {};
+            expect( provider.handleQueryParam( "mbox", "OmnibugTestMbox", rv, raw ) ).toBe( true );
+            expect( rv[provider.key][provider.name].mbox ).toBe( "OmnibugTestMbox" );
+            expect( raw.mbox ).toBe( "OmnibugTestMbox" );
+        } );
+
+        it( "should populate an mboxType in handleCustom", function() {
+            var rv = {}, raw = {};
+            provider.handleCustom( url, rv, raw );
+            expect( rv[provider.key][provider.name].mboxType ).toContain( "standard" );
+            expect( rv[provider.key][provider.name].mboxType.length ).toBe( 8 );
+            expect( raw.mboxType ).toContain( "standard" );
+            expect( raw.mboxType.length ).toBe( 8 );
+        } );
+
+        it( "should populate a clientCode in handleCustom", function() {
+            var rv = {}, raw = {};
+            provider.handleCustom( url, rv, raw );
+            expect( rv[provider.key][provider.name].clientCode ).toEqual( "foobar" );
+            expect( rv[provider.key][provider.name].clientCode.length ).toBe( 6 );
+            expect( raw.clientCode ).toEqual( "foobar" );
+            expect( raw.clientCode.length ).toBe( 6 );
+        } );
+    } );
+
 } );


### PR DESCRIPTION
Something I've been meaning to contribute for a while - adding in Adobe Target as a provider to see mbox requests in Omnibug. Let me know if you have any changes you'd like made.