### PR TITLE
Adding expand/collapse all entries for Firefox

### DIFF
--- a/firefox/chrome/content/omnibug/model.js
+++ b/firefox/chrome/content/omnibug/model.js
@@ -116,6 +116,22 @@ FBL.ns( function() { with( FBL ) {
         },
 
         /**
+         * Called when the expand all button is pushed
+         */
+        expandAll: function() {
+            this.getContext().getPanel("Omnibug").expandAll();
+        },
+
+        /**
+         * Called when the expand all button is pushed
+         */
+        collapseAll: function() {
+            this.getContext().getPanel("Omnibug").collapseAll();
+        },
+
+
+
+        /**
          * Show the prefs menu
          */
         showMenu: function() {

--- a/firefox/chrome/content/omnibug/overlay.xul
+++ b/firefox/chrome/content/omnibug/overlay.xul
@@ -17,6 +17,8 @@
     <commandset id="mainCommandSet">
         <command id="cmd_clear" oncommand="Firebug.Omnibug.clearPanel()"/>
         <command id="cmd_menu" oncommand="Firebug.Omnibug.showMenu()"/>
+        <command id="cmd_expand_all" oncommand="Firebug.Omnibug.expandAll()"/>
+        <command id="cmd_collapse_all" oncommand="Firebug.Omnibug.collapseAll()"/>
     </commandset>
 
     <toolbar id="fbToolbar" align="center">
@@ -28,6 +30,8 @@
                 <toolbarbutton label="Tools" id="omnibugToolsMenu" type="menu">
                     <menupopup>
                         <menuitem label="Choose log file" oncommand="Firebug.Omnibug.omnibugTools( this )"/>
+                        <menuitem label="Expand all entries" command="cmd_expand_all"/>
+                        <menuitem label="Collapse all entries" command="cmd_collapse_all"/>
                     </menupopup>
                 </toolbarbutton>
             </hbox>

--- a/firefox/chrome/content/omnibug/panel.js
+++ b/firefox/chrome/content/omnibug/panel.js
@@ -253,6 +253,45 @@ FBL.ns( function() { with( FBL ) {
             }
         },
 
+        /**
+         * Expands all rows currently closed
+         *
+         * @todo - refactor to not have to use click events (requires updates to OmnibugContext)
+         */
+        expandAll: function() {
+            var el = this.panelNode,
+                children = Array.prototype.slice.call(el.childNodes),
+                clickEvent = new MouseEvent('click');
+            for( var i= 0,l=children.length; i<l; ++i ) {
+                var isExpanded = children[i].querySelector('td.summ > div.hid');
+                if(isExpanded !== null) {
+                    var link = children[i].querySelector('td.exp > a');
+                    if(link !== null) {
+                        children[i].querySelector('td.exp > a').dispatchEvent(clickEvent);
+                    }
+                }
+            }
+        },
+
+        /**
+         * Collapses all rows currently opened
+         *
+         * @todo - refactor to not have to use click events (requires updates to OmnibugContext)
+         */
+        collapseAll: function() {
+            var el = this.panelNode,
+                children = Array.prototype.slice.call(el.childNodes),
+                clickEvent = new MouseEvent('click');
+            for( var i= 0,l=children.length; i<l; ++i ) {
+                var isExpanded = children[i].querySelector('td.summ > div.reg');
+                if(isExpanded !== null) {
+                    var link = children[i].querySelector('td.exp > a');
+                    if(link !== null) {
+                        children[i].querySelector('td.exp > a').dispatchEvent(clickEvent);
+                    }
+                }
+            }
+        },
 
         /**
          * Receives a data object from the model, decodes it, and passes it on to report()

--- a/firefox/chrome/content/omnibug/panel.js
+++ b/firefox/chrome/content/omnibug/panel.js
@@ -263,11 +263,11 @@ FBL.ns( function() { with( FBL ) {
                 children = Array.prototype.slice.call(el.childNodes),
                 clickEvent = new MouseEvent('click');
             for( var i= 0,l=children.length; i<l; ++i ) {
-                var isExpanded = children[i].querySelector('td.summ > div.hid');
-                if(isExpanded !== null) {
+                var isHidden = children[i].querySelector('td.summ > div.hid');
+                if(isHidden !== null) {
                     var link = children[i].querySelector('td.exp > a');
                     if(link !== null) {
-                        children[i].querySelector('td.exp > a').dispatchEvent(clickEvent);
+                        link.dispatchEvent(clickEvent);
                     }
                 }
             }
@@ -287,7 +287,7 @@ FBL.ns( function() { with( FBL ) {
                 if(isExpanded !== null) {
                     var link = children[i].querySelector('td.exp > a');
                     if(link !== null) {
-                        children[i].querySelector('td.exp > a').dispatchEvent(clickEvent);
+                        link.dispatchEvent(clickEvent);
                     }
                 }
             }


### PR DESCRIPTION
Refs #19, allows users to expand or collapse all current entries (useful for debugging lots of click events on a page).

Let me know what you think @simpsora 