### PR TITLE
Fix Doubleclick misattribution

### DIFF
--- a/common/providers.js
+++ b/common/providers.js
@@ -71,6 +71,362 @@ var OmnibugProvider = {
     },
 
 
+    /**
+     * Providers
+     * Ordered by pattern match specificity (decreasing)
+     */
+
+    AUDIENCEMANAGER: {
+        key: "AUDIENCEMANAGER"
+        , name: "Adobe Audience Manager"
+        , pattern: /demdex\.net\//
+        , keys: {
+            d_orgid:  "Adobe Organization ID"
+          , d_rtbd:   "Return Method"
+          , d_cb:     "Callback property"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            var _name;
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+            } else {
+                return false;
+            }
+            return true;
+        },
+        handleCustom: function( url, rv, raw ) {
+            if( url.match( /\/b\/ss\/([\w,]+)\// ) ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name]["rsid"] = RegExp.$1.split( "," );
+                raw["rsid"] = RegExp.$1.split( "," );
+            }
+        }
+    },
+
+    KISSMETRICS : {
+          key: "KISSMETRICS"
+        , name: "KISSmetrics"
+        , pattern: /api\.mixpanel\.com\/track\//
+        , keys: {
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name == "data" ) {
+                var obj = atob( value );
+                try {
+                    var parsed = JSON.parse( obj );
+                    for( var k in parsed ) {
+                        if( parsed.hasOwnProperty( k ) ) {
+                            if( typeof( parsed[k] ) === "object" ) {
+                                for( var innerK in parsed[k] ) {
+                                    if( parsed[k].hasOwnProperty( innerK ) ) {
+                                        rv[this.key] = rv[this.key] || {};
+                                        rv[this.key][k] = rv[this.key][k] || {};
+                                        rv[this.key][k][innerK] = parsed[k][innerK];
+                                        raw[innerK] = parsed[k][innerK];
+                                    }
+                                }
+                            } else {
+                                rv[this.key] = rv[this.key] || {};
+                                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                                rv[this.key][this.name][k] = parsed[k];
+                                raw[k] = parsed[k];
+                            }
+                        }
+                    }
+                } catch( e ) {
+                    // noop
+                }
+
+                return true;
+            } else if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    TORBIT : {
+          key: "TORBIT"
+        , name: "Torbit Insight"
+        , pattern: /insight-beacon\.torbit\.com/
+        , keys: {
+              onready: "onready"
+            , onload:    "onload"
+            , frontend: "frontend"
+            , total_load_time: "Total load time"
+            , red_t: "red_t"
+            , cache_t: "Cache time"
+            , dns_t: "DNS time"
+            , tcp_t: "TCP time"
+            , b_wait_t: "b_wait_t"
+            , b_tran_t: "b_tran_t"
+            , onready_t: "onready time"
+            , onload_t: "onload time"
+            , scr_proc_t: "scr_proc_t"
+            , src: "src"
+            , tbtim: "tbtim"
+            , conversion: "conversion"
+            , tags: "tags"
+            , v: "v"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    QUANTSERVE : {
+          key: "QUANTSERVE"
+        , name: "Quantcast"
+        , pattern: /pixel\.quantserve\.com\/pixel/
+        , keys: {
+              ref: "Referrer"
+            , tzo: "Time zone offset"
+            , dst: "Daylight savings time active?"
+            , sr:  "Screen resolution"
+            , et:  "Timestamp"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    MARKETO : {
+          key: "MARKETO"
+        , name: "Marketo"
+        , pattern: /mktoresp.com\/webevents\/visitWebPage/
+        , keys: {
+              _mchNc: "Timestamp"
+            , _mchCn: "_mchCn"
+            , _mchId: "ID"
+            , _mchTk: "_mchTk"
+            , _mchHo: "Hostname"
+            , _mchPo: "_mchPo"
+            , _mchRu: "Request URL"
+            , _mchPc: "Scheme"
+            , _mchHa: "_mchHa"
+            , _mchRe: "Referrer"
+            , _mchQp: "_mchQp"
+            , _mchVr: "_mchVr"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    NEWRELIC : {
+          key: "NEWRELIC"
+        , name: "NewRelic"
+        , pattern: /beacon.*\.newrelic\.com\//
+        , keys: {
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name == "perf" ) {
+                try {
+                    var parsed = JSON.parse( value );
+                    for( var k in parsed ) {
+                        if( parsed.hasOwnProperty( k ) ) {
+                            if( typeof( parsed[k] ) === "object" ) {
+                                for( var innerK in parsed[k] ) {
+                                    if( parsed[k].hasOwnProperty( innerK ) ) {
+                                        rv[this.key] = rv[this.key] || {};
+                                        rv[this.key][k] = rv[this.key][k] || {};
+                                        rv[this.key][k][innerK] = parsed[k][innerK];
+                                        raw[innerK] = parsed[k][innerK];
+                                    }
+                                }
+                            } else {
+                                rv[this.key] = rv[this.key] || {};
+                                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                                rv[this.key][this.name][k] = parsed[k];
+                                raw[k] = parsed[k];
+                            }
+                        }
+                    }
+                } catch( e ) {
+                    // noop
+                }
+
+                return true;
+            } else if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    KRUX : {
+          key: "KRUX"
+        , name: "Krux"
+        , pattern: /beacon\.krxd\.net\/pixel\.gif/
+        , keys: {
+              geo_country: "Country"
+            , geo_region:  "Region"
+            , geo_city:    "City"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    OPTIMIZELY : {
+          key: "OPTIMIZELY"
+        , name: "Optimizely"
+        , pattern: /optimizely\.com\/event/
+        , keys: {
+              t: "Timestamp"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    SOPHUS3 : {
+          key: "SOPHUS3"
+        , name: "sophus3"
+        , pattern: /sophus3\.com\/i|sophus3\.com\/d/
+        , keys: {
+              r:      "Referrer URL"
+            , tagv:   "Script Version"
+            , Ts:     "Time Stamp"
+            , sr:     "Screen Resolution"
+            , sw:     "Screen Width"
+            , ah:     "Actual Height"
+            , aw:     "Actual Width"
+            , sh:     "Screen Height"
+            , pd:     "Pixel Depth"
+            , cd:     "Colour Depth"
+            , siteID: "SiteID"
+            , ts:     "Ts"
+            , "location": "Location"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    DOUBLECLICK : {
+          key: "DOUBLECLICK"
+        , name: "Doubleclick"
+        , pattern: /\.doubleclick\.net\/(ad|r|pcs|gampad)/
+        , keys: {
+              cat: "Category"
+            , kwd: "Keywords"
+            , sz:  "Size"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    ADOBETARGET : {
+        key: "ADOBETARGET"
+        , name: "Adobe Target"
+        , pattern: /\.tt\.omtrdc\.net\//
+        , keys: {
+            mbox:              "Mbox Name"
+            , mboxType:          "Mbox Type"
+            , mboxCount:         "Mbox Count"
+            , mboxId:            "Mbox ID"
+            , mboxSession:       "Mbox Session"
+            , mboxPC:            "Mbox PC ID"
+            , mboxPage:          "Mbox Page ID"
+            , clientCode:        "Client Code"
+            , mboxHost:          "Page Host"
+            , mboxURL:           "Page URL"
+            , mboxReferrer:      "Page Referrer"
+            , screenHeight:      "Screen Height"
+            , screenWidth:       "Screen Width"
+            , browserWidth:      "Browser Width"
+            , browserHeight:     "Browser Height"
+            , browserTimeOffset: "Browser Timezone Offset"
+            , colorDepth:        "Browser Color Depth"
+            , mboxXDomain:       "CrossDomain Enabled"
+            , mboxTime:          "Timestamp"
+            , mboxVersion:       "Library Version"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        },
+        handleCustom: function( url, rv, raw ) {
+            var matches =  url.match( /\/([^\/]+)\/mbox\/([^\/\?]+)/ );
+            if(matches !== null && matches.length == 3) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name]["clientCode"] = matches[1];
+                rv[this.key][this.name]["mboxType"] = matches[2];
+                raw["clientCode"] = matches[1];
+                raw["mboxType"] = matches[2];
+            }
+        }
+    },
 
     URCHIN: {
           key: "URCHIN"
@@ -268,37 +624,6 @@ var OmnibugProvider = {
         }
     },
 
-    AUDIENCEMANAGER: {
-        key: "AUDIENCEMANAGER"
-        , name: "Adobe Audience Manager"
-        , pattern: /demdex\.net\//
-        , keys: {
-            d_orgid:  "Adobe Organization ID"
-          , d_rtbd:   "Return Method"
-          , d_cb:     "Callback property"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            var _name;
-            if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-            } else {
-                return false;
-            }
-            return true;
-        },
-        handleCustom: function( url, rv, raw ) {
-            if( url.match( /\/b\/ss\/([\w,]+)\// ) ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name]["rsid"] = RegExp.$1.split( "," );
-                raw["rsid"] = RegExp.$1.split( "," );
-            }
-        }
-    },
-
     MONIFORCE: {
           key: "MONIFORCE"
         , name: "Moniforce"
@@ -386,83 +711,6 @@ var OmnibugProvider = {
         },
         handleQueryParam: function( name, value, rv, raw ) {
             if( name in this.keys || name.match( /^WT\./ ) || name.match( /^dcs/ ) ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
-    UNIVERSALANALYTICS : {
-          key: "UNIVERSALANALYTICS"
-        , name: "Universal Analytics"
-        , pattern: /\/collect\/?\?/
-        , keys: {
-              v:      "Protocol Version"
-            , tid:    "Tracking ID"
-            , aip:    "Anonymize IP"
-            , qt:     "Queue Time"
-            , z:      "Cache Buster"
-            , cid:    "Client ID"
-            , sc:     "Session Control"
-            , dr:     "Document Referrer"
-            , cn:     "Campaign Name"
-            , cs:     "Campaign Source"
-            , cm:     "Campaign Medium"
-            , ck:     "Campaign Keyword"
-            , cc:     "Campaign Content"
-            , ci:     "Campaign ID"
-            , gclid:  "Google AdWords ID"
-            , dclid:  "Google Display Ads ID"
-            , sr:     "Screen Resolution"
-            , vp:     "Viewport Size"
-            , de:     "Document Encoding"
-            , sd:     "Screen Colors"
-            , ul:     "User Language"
-            , je:     "Java Enabled"
-            , fl:     "Flash Version"
-            , t:      "Hit Type"
-            , ni:     "Non-Interaction Hit"
-            , dl:     "Document location URL"
-            , dh:     "Document Host Name"
-            , dp:     "Document Path"
-            , dt:     "Document Title"
-            , cd:     "Content Description"
-            , an:     "Application Name"
-            , av:     "Application Version"
-            , ec:     "Event Category"
-            , ea:     "Event Action"
-            , el:     "Event Label"
-            , ev:     "Event Value"
-            , ti:     "Transaction ID"
-            , ta:     "Transaction Affiliation"
-            , tr:     "Transaction Revenue"
-            , ts:     "Transaction Shipping"
-            , tt:     "Transaction Tax"
-            , "in":   "Item Name"
-            , ip:     "Item Price"
-            , iq:     "Item Quantity"
-            , ic:     "Item Code"
-            , iv:     "Item Category"
-            , cu:     "Currency Code"
-            , sn:     "Social Network"
-            , sa:     "Social Action"
-            , st:     "Social Action Target"
-            , utl:    "User timing label"
-            , plt:    "Page load time"
-            , dns:    "DNS time"
-            , pdt:    "Page download time"
-            , rrt:    "Redirect response time"
-            , tcp:    "TCP connect time"
-            , srt:    "Server response time"
-            , exd:    "Exception description"
-            , exf:    "Is exception fatal?"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name in this.keys ) {
                 rv[this.key] = rv[this.key] || {};
                 rv[this.key][this.name] = rv[this.key][this.name] || {};
                 rv[this.key][this.name][name] = value;
@@ -625,52 +873,6 @@ var OmnibugProvider = {
         }
     },
 
-    KISSMETRICS : {
-          key: "KISSMETRICS"
-        , name: "KISSmetrics"
-        , pattern: /api\.mixpanel\.com\/track\//
-        , keys: {
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name == "data" ) {
-                var obj = atob( value );
-                try {
-                    var parsed = JSON.parse( obj );
-                    for( var k in parsed ) {
-                        if( parsed.hasOwnProperty( k ) ) {
-                            if( typeof( parsed[k] ) === "object" ) {
-                                for( var innerK in parsed[k] ) {
-                                    if( parsed[k].hasOwnProperty( innerK ) ) {
-                                        rv[this.key] = rv[this.key] || {};
-                                        rv[this.key][k] = rv[this.key][k] || {};
-                                        rv[this.key][k][innerK] = parsed[k][innerK];
-                                        raw[innerK] = parsed[k][innerK];
-                                    }
-                                }
-                            } else {
-                                rv[this.key] = rv[this.key] || {};
-                                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                                rv[this.key][this.name][k] = parsed[k];
-                                raw[k] = parsed[k];
-                            }
-                        }
-                    }
-                } catch( e ) {
-                    // noop
-                }
-
-                return true;
-            } else if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
     FBLIKE : {
           key: "FBLIKE"
         , name: "Facebook"
@@ -691,95 +893,6 @@ var OmnibugProvider = {
             , extended_social_context: "Extended social context"
             , action:      "Action"
             , height:      "Height"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
-    TORBIT : {
-          key: "TORBIT"
-        , name: "Torbit Insight"
-        , pattern: /insight-beacon\.torbit\.com/
-        , keys: {
-              onready: "onready"
-            , onload:    "onload"
-            , frontend: "frontend"
-            , total_load_time: "Total load time"
-            , red_t: "red_t"
-            , cache_t: "Cache time"
-            , dns_t: "DNS time"
-            , tcp_t: "TCP time"
-            , b_wait_t: "b_wait_t"
-            , b_tran_t: "b_tran_t"
-            , onready_t: "onready time"
-            , onload_t: "onload time"
-            , scr_proc_t: "scr_proc_t"
-            , src: "src"
-            , tbtim: "tbtim"
-            , conversion: "conversion"
-            , tags: "tags"
-            , v: "v"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
-    QUANTSERVE : {
-          key: "QUANTSERVE"
-        , name: "Quantcast"
-        , pattern: /pixel\.quantserve\.com\/pixel/
-        , keys: {
-              ref: "Referrer"
-            , tzo: "Time zone offset"
-            , dst: "Daylight savings time active?"
-            , sr:  "Screen resolution"
-            , et:  "Timestamp"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
-    MARKETO : {
-          key: "MARKETO"
-        , name: "Marketo"
-        , pattern: /mktoresp.com\/webevents\/visitWebPage/
-        , keys: {
-              _mchNc: "Timestamp"
-            , _mchCn: "_mchCn"
-            , _mchId: "ID"
-            , _mchTk: "_mchTk"
-            , _mchHo: "Hostname"
-            , _mchPo: "_mchPo"
-            , _mchRu: "Request URL"
-            , _mchPc: "Scheme"
-            , _mchHa: "_mchHa"
-            , _mchRe: "Referrer"
-            , _mchQp: "_mchQp"
-            , _mchVr: "_mchVr"
         },
         handleQueryParam: function( name, value, rv, raw ) {
             if( name in this.keys ) {
@@ -817,192 +930,6 @@ var OmnibugProvider = {
                 return true;
             }
             return false;
-        }
-    },
-
-    NEWRELIC : {
-          key: "NEWRELIC"
-        , name: "NewRelic"
-        , pattern: /beacon.*\.newrelic\.com\//
-        , keys: {
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name == "perf" ) {
-                try {
-                    var parsed = JSON.parse( value );
-                    for( var k in parsed ) {
-                        if( parsed.hasOwnProperty( k ) ) {
-                            if( typeof( parsed[k] ) === "object" ) {
-                                for( var innerK in parsed[k] ) {
-                                    if( parsed[k].hasOwnProperty( innerK ) ) {
-                                        rv[this.key] = rv[this.key] || {};
-                                        rv[this.key][k] = rv[this.key][k] || {};
-                                        rv[this.key][k][innerK] = parsed[k][innerK];
-                                        raw[innerK] = parsed[k][innerK];
-                                    }
-                                }
-                            } else {
-                                rv[this.key] = rv[this.key] || {};
-                                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                                rv[this.key][this.name][k] = parsed[k];
-                                raw[k] = parsed[k];
-                            }
-                        }
-                    }
-                } catch( e ) {
-                    // noop
-                }
-
-                return true;
-            } else if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
-    KRUX : {
-          key: "KRUX"
-        , name: "Krux"
-        , pattern: /beacon\.krxd\.net\/pixel\.gif/
-        , keys: {
-              geo_country: "Country"
-            , geo_region:  "Region"
-            , geo_city:    "City"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
-    OPTIMIZELY : {
-          key: "OPTIMIZELY"
-        , name: "Optimizely"
-        , pattern: /optimizely\.com\/event/
-        , keys: {
-              t: "Timestamp"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
-    SOPHUS3 : {
-          key: "SOPHUS3"
-        , name: "sophus3"
-        , pattern: /sophus3\.com\/i|sophus3\.com\/d/
-        , keys: {
-              r:      "Referrer URL"
-            , tagv:   "Script Version"
-            , Ts:     "Time Stamp"
-            , sr:     "Screen Resolution"
-            , sw:     "Screen Width"
-            , ah:     "Actual Height"
-            , aw:     "Actual Width"
-            , sh:     "Screen Height"
-            , pd:     "Pixel Depth"
-            , cd:     "Colour Depth"
-            , siteID: "SiteID"
-            , ts:     "Ts"
-            , "location": "Location"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
-    DOUBLECLICK : {
-          key: "DOUBLECLICK"
-        , name: "Doubleclick"
-        , pattern: /\.doubleclick\.net\/ad/
-        , keys: {
-              cat: "Category"
-            , kwd: "Keywords"
-            , sz:  "Size"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        }
-    },
-
-    ADOBETARGET : {
-        key: "ADOBETARGET"
-        , name: "Adobe Target"
-        , pattern: /\.tt\.omtrdc\.net\//
-        , keys: {
-            mbox:              "Mbox Name"
-            , mboxType:          "Mbox Type"
-            , mboxCount:         "Mbox Count"
-            , mboxId:            "Mbox ID"
-            , mboxSession:       "Mbox Session"
-            , mboxPC:            "Mbox PC ID"
-            , mboxPage:          "Mbox Page ID"
-            , clientCode:        "Client Code"
-            , mboxHost:          "Page Host"
-            , mboxURL:           "Page URL"
-            , mboxReferrer:      "Page Referrer"
-            , screenHeight:      "Screen Height"
-            , screenWidth:       "Screen Width"
-            , browserWidth:      "Browser Width"
-            , browserHeight:     "Browser Height"
-            , browserTimeOffset: "Browser Timezone Offset"
-            , colorDepth:        "Browser Color Depth"
-            , mboxXDomain:       "CrossDomain Enabled"
-            , mboxTime:          "Timestamp"
-            , mboxVersion:       "Library Version"
-        },
-        handleQueryParam: function( name, value, rv, raw ) {
-            if( name in this.keys ) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name][name] = value;
-                raw[name] = value;
-                return true;
-            }
-            return false;
-        },
-        handleCustom: function( url, rv, raw ) {
-            var matches =  url.match( /\/([^\/]+)\/mbox\/([^\/\?]+)/ );
-            if(matches !== null && matches.length == 3) {
-                rv[this.key] = rv[this.key] || {};
-                rv[this.key][this.name] = rv[this.key][this.name] || {};
-                rv[this.key][this.name]["clientCode"] = matches[1];
-                rv[this.key][this.name]["mboxType"] = matches[2];
-                raw["clientCode"] = matches[1];
-                raw["mboxType"] = matches[2];
-            }
         }
     },
 
@@ -1082,6 +1009,83 @@ var OmnibugProvider = {
         handleQueryParam: function( name, value, rv, raw ) {
             var match;
             if ( name in this.keys ) {
+                rv[this.key] = rv[this.key] || {};
+                rv[this.key][this.name] = rv[this.key][this.name] || {};
+                rv[this.key][this.name][name] = value;
+                raw[name] = value;
+                return true;
+            }
+            return false;
+        }
+    },
+
+    UNIVERSALANALYTICS : {
+          key: "UNIVERSALANALYTICS"
+        , name: "Universal Analytics"
+        , pattern: /\/collect\/?\?/
+        , keys: {
+              v:      "Protocol Version"
+            , tid:    "Tracking ID"
+            , aip:    "Anonymize IP"
+            , qt:     "Queue Time"
+            , z:      "Cache Buster"
+            , cid:    "Client ID"
+            , sc:     "Session Control"
+            , dr:     "Document Referrer"
+            , cn:     "Campaign Name"
+            , cs:     "Campaign Source"
+            , cm:     "Campaign Medium"
+            , ck:     "Campaign Keyword"
+            , cc:     "Campaign Content"
+            , ci:     "Campaign ID"
+            , gclid:  "Google AdWords ID"
+            , dclid:  "Google Display Ads ID"
+            , sr:     "Screen Resolution"
+            , vp:     "Viewport Size"
+            , de:     "Document Encoding"
+            , sd:     "Screen Colors"
+            , ul:     "User Language"
+            , je:     "Java Enabled"
+            , fl:     "Flash Version"
+            , t:      "Hit Type"
+            , ni:     "Non-Interaction Hit"
+            , dl:     "Document location URL"
+            , dh:     "Document Host Name"
+            , dp:     "Document Path"
+            , dt:     "Document Title"
+            , cd:     "Content Description"
+            , an:     "Application Name"
+            , av:     "Application Version"
+            , ec:     "Event Category"
+            , ea:     "Event Action"
+            , el:     "Event Label"
+            , ev:     "Event Value"
+            , ti:     "Transaction ID"
+            , ta:     "Transaction Affiliation"
+            , tr:     "Transaction Revenue"
+            , ts:     "Transaction Shipping"
+            , tt:     "Transaction Tax"
+            , "in":   "Item Name"
+            , ip:     "Item Price"
+            , iq:     "Item Quantity"
+            , ic:     "Item Code"
+            , iv:     "Item Category"
+            , cu:     "Currency Code"
+            , sn:     "Social Network"
+            , sa:     "Social Action"
+            , st:     "Social Action Target"
+            , utl:    "User timing label"
+            , plt:    "Page load time"
+            , dns:    "DNS time"
+            , pdt:    "Page download time"
+            , rrt:    "Redirect response time"
+            , tcp:    "TCP connect time"
+            , srt:    "Server response time"
+            , exd:    "Exception description"
+            , exf:    "Is exception fatal?"
+        },
+        handleQueryParam: function( name, value, rv, raw ) {
+            if( name in this.keys ) {
                 rv[this.key] = rv[this.key] || {};
                 rv[this.key][this.name] = rv[this.key][this.name] || {};
                 rv[this.key][this.name][name] = value;

--- a/firefox/chrome/content/omnibug/options.xul
+++ b/firefox/chrome/content/omnibug/options.xul
@@ -50,6 +50,7 @@
             <preference id="pref-prov-SOPHUS3" name="extensions.omnibug.provider.SOPHUS3" type="bool" />
             <preference id="pref-prov-DOUBLECLICK" name="extensions.omnibug.provider.DOUBLECLICK" type="bool" />
             <preference id="pref-prov-ADOBETARGET" name="extensions.omnibug.provider.ADOBETARGET" type="bool" />
+            <preference id="pref-prov-ZAIUS" name="extensions.omnibug.provider.ZAIUS" type="bool" />
         </preferences>
 
         <!-- file logging -->

--- a/firefox/defaults/preferences/omnibug.js
+++ b/firefox/defaults/preferences/omnibug.js
@@ -42,3 +42,4 @@ pref( "extensions.omnibug.provider.OPTIMIZELY", true );
 pref( "extensions.omnibug.provider.SOPHUS3", true );
 pref( "extensions.omnibug.provider.DOUBLECLICK", true );
 pref( "extensions.omnibug.provider.ADOBETARGET", true );
+pref( "extensions.omnibug.provider.ZAIUS", true );

--- a/test/common/providerTest.js
+++ b/test/common/providerTest.js
@@ -277,7 +277,6 @@ describe( "Provider", function() {
 
     // @TODO: crowdfactory??
 
-    
     describe( "NewRelic", function() {
         var url = "http://beacon-1.newrelic.com/1/1d1110a9fb?a=120775&be=523&qt=0&ap=258&dc=786&fe=3467&to=YlZaNkpUXxcDU01QV1sccjFoGmYhIB1wd34aWUsSF0dUBU1YVlRdG1lLEg%3D%3D&v=40&jsonp=NREUM.setToken&perf=%7B%22timing%22%3A%7B%22of%22%3A1373109832853%2C%20%22n%22%3A0%2C%20%22dl%22%3A457%2C%20%22di%22%3A1309%2C%20%22ds%22%3A1309%2C%20%22de%22%3A1362%2C%20%22dc%22%3A3947%2C%20%22l%22%3A3947%2C%20%22le%22%3A3990%2C%20%22f%22%3A0%2C%20%22dn%22%3A0%2C%20%22dne%22%3A0%2C%20%22c%22%3A0%2C%20%22ce%22%3A0%2C%20%22rq%22%3A2%2C%20%22rp%22%3A432%2C%20%22rpe%22%3A452%7D%2C%20%22navigation%22%3A%7B%22ty%22%3A1%7D%7D",
             provider = OmnibugProvider.getProviderForUrl( url );
@@ -394,6 +393,24 @@ describe( "Provider", function() {
             expect( rv[provider.key][provider.name].clientCode.length ).toBe( 6 );
             expect( raw.clientCode ).toEqual( "foobar" );
             expect( raw.clientCode.length ).toBe( 6 );
+        } );
+    } );
+
+
+    describe( "Zaius", function() {
+        var url = "https://jumbe.zaius.com/v2/zaius.gif?resolution=3840x2400&color_depth=24-bit&viewport=2880x742&source=google&medium=organic&java=0&flash=24.0%20r0&language=en-us&character_set=utf-8&days_since_last_visit=0&server_connect_time=589&server_response_time=1304&page_download_time=321&page_load_time=1911&total_load_time=4176&hostname=www.modaoperandi.com&page=%2F&title=Moda%20Operandi&u=2003075067&vuid=29b4a237-7dfe-4e17-ac0d-c49b2ef2bd03&new_user=0&zaius_js_version=2.1.4&tracker_id=d_43qkTBbK0DGIVTYFiCdQ&event_type=pageview&logged_in=not%20signed%20in",
+            provider = OmnibugProvider.getProviderForUrl( url );
+
+        it( "should return the Zaius provider", function() {
+            expect( provider.key ).toBe( "ZAIUS" );
+            expect( provider.name ).toBe( "Zaius" );
+        } );
+
+        it( "should allow a known key", function() {
+            var rv = {}, raw = {};
+            expect( provider.handleQueryParam( "resolution", "3840x2400", rv, raw ) ).toBe( true );
+            expect( rv[provider.key][provider.name].resolution ).toBe( "3840x2400" );
+            expect( raw.resolution ).toBe( "3840x2400" );
         } );
     } );
 


### PR DESCRIPTION
Fixes a bug where the very permissive pattern match for GA was matching a Doubleclick event.  Reorders providers so that the more specific (e.g. those with domains) match before providers with just a path match.

Also adds missing Zaius prefs and tests.